### PR TITLE
Fix context error and handle invalid inputs

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -43,6 +43,9 @@ const Input: React.FC<InputProps> = ({
   };
 
   const control = formState[formControlName];
+  if (!control) {
+    throw new Error(`No form control found for name: ${formControlName}`);
+  }
 
   return (
     <input

--- a/src/components/context/useFormContext.ts
+++ b/src/components/context/useFormContext.ts
@@ -21,7 +21,7 @@ interface FormControlState {
 export const useFormContext = (): FormContextType => {
   const context = useContext(FormContext);
   if (!context) {
-    throw new Error("useFormContext must be used within a FormProvider");
+    throw new Error("useFormContext must be used within a FormThing component");
   }
   return context;
 };


### PR DESCRIPTION
## Summary
- prevent invalid `formControlName` usage in `Input`
- clarify provider name in `useFormContext`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run rollup`

------
https://chatgpt.com/codex/tasks/task_e_6847c2753c6c83308dbd68e351805ddc